### PR TITLE
Feature: add `LoggerDict`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,4 +34,5 @@ jobs:
         flake8 .
     - name: Test with pytest
       run: |
+        export PYTHONPATH=$GITHUB_WORKSPACE:$PYTHONPATH:
         pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flake8==3.9.2
+isort==4.3.21
 pytest==5.4.2

--- a/src/logging_decorator.py
+++ b/src/logging_decorator.py
@@ -52,3 +52,7 @@ class LoggerDict(dict):
 
         for logger, level in zip(loggers, levels):
             self[logger.name] = (logger, level)
+
+    def remove_loggers(self, logger_names: Iterable[str]):
+        for logger_name in logger_names:
+            self.pop(key=logger_name)

--- a/src/logging_decorator.py
+++ b/src/logging_decorator.py
@@ -1,0 +1,54 @@
+import logging
+from logging import Logger
+from typing import Any, Iterable, List, Optional, Type, Union
+
+Loggers = Union[Logger, Iterable[Logger]]
+Levels = Union[int, Iterable[int]]
+
+Argument = Union[Loggers, Levels]
+ArgumentClass = Union[Type[Logger], Type[int]]
+ArgumentAsList = Union[List[Logger], List[int]]
+
+
+class LoggerDict(dict):
+
+    def __init__(self,
+                 loggers: Optional[Loggers] = None,
+                 levels: Optional[Levels] = logging.DEBUG,
+                 *args: Any,
+                 **kwargs: Any
+                 ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.add_loggers(loggers=loggers, levels=levels)
+
+    @staticmethod
+    def _parse_argument(argument: Argument,
+                        argument_type: ArgumentClass
+                        ) -> ArgumentAsList:
+        if argument is None:
+            argument_list = []
+        elif isinstance(argument, argument_type):
+            argument_list = [argument]
+        elif isinstance(argument, Iterable):
+            argument_list = list(argument)
+            assert all(isinstance(arg, argument_type) for arg in argument_list)
+        else:
+            raise TypeError(f'{type(argument)} does not match {argument_type}')
+        return argument_list
+
+    def add_loggers(self,
+                    loggers: Loggers,
+                    levels: Optional[Levels] = logging.DEBUG,
+                    ) -> None:
+        loggers = self._parse_argument(loggers, argument_type=logging.Logger)
+        levels = self._parse_argument(levels, argument_type=int)
+
+        if len(levels) == 1:
+            levels = len(loggers) * levels
+
+        error_message = 'loggers and levels must be the same length'
+        assert len(loggers) == len(levels), error_message
+
+        for logger, level in zip(loggers, levels):
+            self[logger.name] = (logger, level)

--- a/tests/test_pass.py
+++ b/tests/test_pass.py
@@ -1,2 +1,5 @@
-def test_pass():
-    pass
+from src.logging_decorator import LoggerDict
+
+
+def test_logger_dict_subclassing():
+    assert issubclass(LoggerDict, dict)


### PR DESCRIPTION
Add the `LoggerDict` class to the `logging_decorator` module. This class inherits from `dict` and has the following parameters:
- `loggers`: (default = `None`) a `logging.Logger` instance or iterable of `logging.Logger` instances.
- `levels`: (default = `logging.DEBUG`) a logging level or iterable of logging levels

`LoggerDict` will be initialized with the `.name` attribute of `loggers` for keys and tuples of `(logger, level)` for values. The class emits the following methods:
- `add_loggers(loggers, levels=logging.DEBUG)`
  - This method is called by the constructor and has the behavior described above.
- `remove_loggers(logger_names)`
  - Remove the keys listed in the iterable `logger_names`